### PR TITLE
Fix testing

### DIFF
--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -13,7 +13,7 @@
 ; limitations under the License.
 
 global long_mode_start
-extern main
+extern rust_main
 
 section .text
 bits 64
@@ -21,7 +21,7 @@ long_mode_start:
     call setup_SSE
 
     ; call rust main
-    call main
+    call rust_main
 .os_returned:
     ; rust main returned, print `OS returned!`
     mov rax, 0x4f724f204f534f4f

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,10 @@ pub extern fn rust_main() {
     loop{}
 }
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] extern fn panic_fmt() -> ! {loop{}}
+#[cfg(not(test))]
+#[lang = "eh_personality"]
+extern fn eh_personality() {}
+
+#[cfg(not(test))]
+#[lang = "panic_fmt"]
+extern fn panic_fmt() -> ! {loop{}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate rlibc;
 use core::intrinsics::offset;
 
 #[no_mangle]
-pub extern fn main() {
+pub extern fn rust_main() {
     // ATTENTION: we have a very small stack and no guard page
     let x = ["Hello", " ", "World", "!"];
     let screen_pointer = 0xb8000 as *const u16;


### PR DESCRIPTION
This requires renaming `main` as `cargo test` imports `std`, which defines its own not mangled `main`. Furthermore, the `eh_personality` and `panic_fmt` lang are already implemented by `std`.